### PR TITLE
Finish react-router v7 type-safety onboarding

### DIFF
--- a/app/data/stations.ts
+++ b/app/data/stations.ts
@@ -1,25 +1,29 @@
 import { stations } from "./stations.json";
 
+import type { Station } from "~/types/station";
+
 export type StationLocation = {
   latitude: number;
   longitude: number;
   stationId: number;
 };
 
-export const ORDERED_STATIONS = stations.sort((stationA, stationB) => {
-  if (stationA.name < stationB.name) {
-    return -1;
-  } else if (stationA.name > stationB.name) {
-    return 1;
-  } else {
-    if (stationA.id < stationB.id) {
+export const ORDERED_STATIONS: Station[] = (stations as Station[]).sort(
+  (stationA, stationB) => {
+    if (stationA.name < stationB.name) {
       return -1;
-    } else if (stationA.id > stationB.id) {
+    } else if (stationA.name > stationB.name) {
       return 1;
+    } else {
+      if (stationA.id < stationB.id) {
+        return -1;
+      } else if (stationA.id > stationB.id) {
+        return 1;
+      }
     }
-  }
-  return 0;
-});
+    return 0;
+  },
+);
 
 export const STATION_LOCATIONS: StationLocation[] = stations.map((station) => ({
   ...station.location,

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -6,7 +6,6 @@ import {
   Scripts,
   ScrollRestoration,
   isRouteErrorResponse,
-  useRouteError,
 } from "react-router";
 
 import type { Route } from "./+types/root";
@@ -58,8 +57,7 @@ export default function App() {
   );
 }
 
-export const ErrorBoundary = () => {
-  const error = useRouteError();
+export const ErrorBoundary = ({ error }: Route.ErrorBoundaryProps) => {
   if (isRouteErrorResponse(error) && error.status === 404) {
     // i can't know how to hear anymore about 404s!
   } else {

--- a/app/root.tsx
+++ b/app/root.tsx
@@ -8,7 +8,8 @@ import {
   isRouteErrorResponse,
   useRouteError,
 } from "react-router";
-import type { MetaFunction } from "react-router";
+
+import type { Route } from "./+types/root";
 
 import styles from "~/styles/global.css?url";
 
@@ -29,7 +30,7 @@ export function links() {
   ];
 }
 
-export const meta: MetaFunction = () => {
+export const meta: Route.MetaFunction = () => {
   return [{ title: "Slow Zone" }];
 };
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,8 +1,8 @@
-import { useLoaderData } from "react-router";
-
 import { Star } from "~/components/icons/Star";
 import { StationListItem } from "~/components/StationListItem";
 import { getFavoriteStations } from "~/store/FavoriteStations";
+
+import type { Route } from "./+types/_index";
 
 export function clientLoader() {
   const stations = getFavoriteStations();
@@ -21,9 +21,7 @@ export function HydrateFallback() {
     </>
   );
 }
-export default function Index() {
-  const stations = useLoaderData<typeof clientLoader>();
-
+export default function Index({ loaderData: stations }: Route.ComponentProps) {
   return (
     <>
       <div className="page__header">

--- a/app/routes/follow.$runId.ts
+++ b/app/routes/follow.$runId.ts
@@ -1,11 +1,11 @@
-import type { LoaderFunctionArgs } from "react-router";
 import invariant from "tiny-invariant";
 
 import { client } from "~/util/slow-zone.server";
 
+import type { Route } from "./+types/follow.$runId";
 import type { Arrival } from "~/types/arrival";
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ params }: Route.LoaderArgs) {
   const { runId } = params;
   invariant(runId, "runId is required");
 

--- a/app/routes/follow.$runId.ts
+++ b/app/routes/follow.$runId.ts
@@ -10,6 +10,7 @@ export async function loader({ params }: Route.LoaderArgs) {
   invariant(runId, "runId is required");
 
   try {
+    // TODO: drop cast once slow-zone narrows followTrain's Promise<unknown> return.
     const arrivals = (await client.followTrain(runId)) as Arrival[];
     return { arrivals, error: null };
   } catch (error) {

--- a/app/routes/nearby.stations.ts
+++ b/app/routes/nearby.stations.ts
@@ -1,4 +1,3 @@
-import type { LoaderFunctionArgs } from "react-router";
 import { getDistance, orderByDistance, convertDistance } from "geolib";
 import invariant from "tiny-invariant";
 
@@ -8,10 +7,12 @@ import {
   type StationLocation,
 } from "~/data/stations";
 
+import type { Route } from "./+types/nearby.stations";
+
 const findStation = (stationId: number) =>
   ORDERED_STATIONS.find((station) => station.id === stationId);
 
-export async function loader({ request }: LoaderFunctionArgs) {
+export async function loader({ request }: Route.LoaderArgs) {
   let latitude, longitude, count;
 
   try {

--- a/app/routes/nearby.tsx
+++ b/app/routes/nearby.tsx
@@ -5,7 +5,7 @@ import { StationListItem } from "~/components/StationListItem";
 import nearbyStyles from "~/styles/nearby.css?url";
 import stationStyles from "~/styles/stations.css?url";
 
-import type { Station } from "~/types/station";
+import type { loader as nearbyStationsLoader } from "./nearby.stations";
 
 function LoadingState() {
   return (
@@ -39,7 +39,7 @@ export function meta() {
 
 export default function Nearby() {
   const [located, setLocated] = useState(false);
-  const stationFetcher = useFetcher();
+  const stationFetcher = useFetcher<typeof nearbyStationsLoader>();
 
   const fetchStations = (lat: number, lng: number) => {
     const qs = new URLSearchParams();
@@ -93,7 +93,7 @@ export default function Nearby() {
       {located ? (
         stationFetcher.data?.stations ? (
           <ul className="station-list">
-            {stationFetcher.data?.stations.map((station: Station) => {
+            {stationFetcher.data?.stations.map((station) => {
               const { id, name, lines } = station;
               return (
                 <StationListItem key={id} id={id} name={name} lines={lines} />

--- a/app/routes/recent.tsx
+++ b/app/routes/recent.tsx
@@ -1,5 +1,3 @@
-import { useLoaderData } from "react-router";
-
 import { StationListItem } from "~/components/StationListItem";
 import { getRecentStations } from "~/store/RecentStations";
 
@@ -42,9 +40,7 @@ export function HydrateFallback() {
   );
 }
 
-export default function Recent() {
-  const stations = useLoaderData<typeof clientLoader>();
-
+export default function Recent({ loaderData: stations }: Route.ComponentProps) {
   return (
     <>
       <div className="page__header">

--- a/app/routes/recent.tsx
+++ b/app/routes/recent.tsx
@@ -1,8 +1,9 @@
-import type { ClientLoaderFunctionArgs } from "react-router";
 import { useLoaderData } from "react-router";
 
 import { StationListItem } from "~/components/StationListItem";
 import { getRecentStations } from "~/store/RecentStations";
+
+import type { Route } from "./+types/recent";
 
 function EmptyState() {
   return (
@@ -23,7 +24,7 @@ export function meta() {
   ];
 }
 
-export function clientLoader({ request }: ClientLoaderFunctionArgs) {
+export function clientLoader({ request }: Route.ClientLoaderArgs) {
   const stations = getRecentStations();
   return stations;
 }

--- a/app/routes/stations.$stationId.map.ts
+++ b/app/routes/stations.$stationId.map.ts
@@ -2,7 +2,7 @@ import { cacheHeader } from "pretty-cache-header";
 
 import { STATION_LOCATIONS } from "~/data/stations";
 
-import type { LoaderFunction } from "react-router";
+import type { Route } from "./+types/stations.$stationId.map";
 
 function notFound() {
   throw new Response("Not Found", {
@@ -38,7 +38,7 @@ function buildQueryString({
   return params.toString();
 }
 
-export const loader: LoaderFunction = async ({ params }) => {
+export const loader = async ({ params }: Route.LoaderArgs) => {
   const { stationId } = params;
   if (!stationId) return notFound();
 

--- a/app/routes/stations.$stationId.tsx
+++ b/app/routes/stations.$stationId.tsx
@@ -1,4 +1,3 @@
-import type { LoaderFunctionArgs, MetaFunction } from "react-router";
 import { useLoaderData } from "react-router";
 import { useEffect, useState } from "react";
 import invariant from "tiny-invariant";
@@ -16,6 +15,7 @@ import {
 import { pushRecentStation } from "~/store/RecentStations";
 import { client } from "~/util/slow-zone.server";
 
+import type { Route } from "./+types/stations.$stationId";
 import type { Arrival } from "~/types/arrival";
 import type { Station } from "~/types/station";
 
@@ -24,7 +24,7 @@ type LoaderData = {
   arrivals: Arrival[];
 };
 
-export async function loader({ params }: LoaderFunctionArgs) {
+export async function loader({ params }: Route.LoaderArgs) {
   const { stationId } = params;
   invariant(stationId, "stationId is required");
   const station = ORDERED_STATIONS.find(
@@ -41,12 +41,11 @@ export async function loader({ params }: LoaderFunctionArgs) {
   return { station, arrivals };
 }
 
-export const meta: MetaFunction<typeof loader> = ({ data }) => {
+export const meta: Route.MetaFunction = ({ data }) => {
   return [
     {
       title:
-        `${(data as LoaderData)?.station?.name} • Slow Zone` ||
-        "Station • Slow Zone",
+        `${data?.station?.name} • Slow Zone` || "Station • Slow Zone",
     },
   ];
 };

--- a/app/routes/stations.$stationId.tsx
+++ b/app/routes/stations.$stationId.tsx
@@ -1,4 +1,3 @@
-import { useLoaderData } from "react-router";
 import { useEffect, useState } from "react";
 import invariant from "tiny-invariant";
 
@@ -17,12 +16,6 @@ import { client } from "~/util/slow-zone.server";
 
 import type { Route } from "./+types/stations.$stationId";
 import type { Arrival } from "~/types/arrival";
-import type { Station } from "~/types/station";
-
-type LoaderData = {
-  station: Station;
-  arrivals: Arrival[];
-};
 
 export async function loader({ params }: Route.LoaderArgs) {
   const { stationId } = params;
@@ -36,7 +29,8 @@ export async function loader({ params }: Route.LoaderArgs) {
     });
   }
 
-  const arrivals = await client.getArrivalsForStation(stationId);
+  // TODO: drop cast once slow-zone narrows getArrivalsForStation's Promise<unknown> return.
+  const arrivals = (await client.getArrivalsForStation(stationId)) as Arrival[];
 
   return { station, arrivals };
 }
@@ -49,8 +43,8 @@ export const meta: Route.MetaFunction = ({ data }) => {
   ];
 };
 
-export default function StationId() {
-  const { station, arrivals } = useLoaderData<LoaderData>();
+export default function StationId({ loaderData }: Route.ComponentProps) {
+  const { station, arrivals } = loaderData;
   const { name, id, lines } = station;
 
   const [favorite, setFavorite] = useState(false);

--- a/app/routes/stations.$stationId.tsx
+++ b/app/routes/stations.$stationId.tsx
@@ -44,8 +44,7 @@ export async function loader({ params }: Route.LoaderArgs) {
 export const meta: Route.MetaFunction = ({ data }) => {
   return [
     {
-      title:
-        `${data?.station?.name} • Slow Zone` || "Station • Slow Zone",
+      title: `${data?.station?.name ?? "Station"} • Slow Zone`,
     },
   ];
 };

--- a/app/routes/stations._index.tsx
+++ b/app/routes/stations._index.tsx
@@ -7,6 +7,7 @@ import { ListFilter } from "~/components/ListFilter";
 import { StationListItem } from "~/components/StationListItem";
 import { ORDERED_STATIONS } from "~/data/stations";
 
+import type { Route } from "./+types/stations._index";
 import type { Line } from "~/types/line";
 import type { Station } from "~/types/station";
 
@@ -29,7 +30,7 @@ export function loader() {
   );
 }
 
-export function headers({ loaderHeaders }: { loaderHeaders: Headers }) {
+export function headers({ loaderHeaders }: Route.HeadersArgs) {
   return {
     "Cache-Control": loaderHeaders.get("Cache-Control"),
   };

--- a/app/routes/stations._index.tsx
+++ b/app/routes/stations._index.tsx
@@ -1,5 +1,4 @@
 import { data } from "react-router";
-import { useLoaderData } from "react-router";
 import { cacheHeader } from "pretty-cache-header";
 import { useState } from "react";
 
@@ -10,10 +9,6 @@ import { ORDERED_STATIONS } from "~/data/stations";
 import type { Route } from "./+types/stations._index";
 import type { Line } from "~/types/line";
 import type { Station } from "~/types/station";
-
-type LoaderData = {
-  stations: Station[];
-};
 
 export function loader() {
   return data(
@@ -36,8 +31,8 @@ export function headers({ loaderHeaders }: Route.HeadersArgs) {
   };
 }
 
-export default function StationList() {
-  const { stations } = useLoaderData<LoaderData>();
+export default function StationList({ loaderData }: Route.ComponentProps) {
+  const { stations } = loaderData;
   const allLines: Line[] = [
     "blue",
     "brown",


### PR DESCRIPTION
## tl;dr

Finishes the v7 type-safety migration. Every route now consumes the per-route `Route.*` namespace from `./+types/<route>`, replacing the generic types that still work but don't narrow per-route. Incidentally fixes a title fallback that never fired.

## What changed?

Type plumbing — no runtime behavior change:

- Routes swap `LoaderFunctionArgs` / `ActionFunctionArgs` /  `MetaFunction<typeof loader>` / `LoaderFunction` /  `ClientLoaderFunctionArgs` for the matching `Route.*` types.  Inline `{ loaderHeaders: Headers }` on headers gets typed via  `Route.HeadersArgs`.
- Default exports move from `useLoaderData<LoaderData>()` +  hand-rolled `LoaderData` types to `{ loaderData }:  Route.ComponentProps`. Two `LoaderData` types deleted.
- `nearby.tsx`'s `useFetcher()` picks up the loader type from  `./nearby.stations`, dropping a manual `(station: Station)`  annotation on the map callback.
- `root.tsx`'s `ErrorBoundary` takes `{ error }:  Route.ErrorBoundaryProps` instead of calling `useRouteError()`.
- `ORDERED_STATIONS` annotated as `Station[]` at the data  boundary. Typegen flowing `loaderData` through from the  loader's inferred return revealed that `stations.json`'s  widened `string[]` was masquerading as `Line[]` via the  hand-rolled `LoaderData` types. The cast is at the JSON→TS  seam; every `lines` value in `stations.json` is in the `Line`  union.

Behavior change:

- Station page title now falls back to `Station • Slow Zone` when route data is missing, instead of rendering literally `undefined • Slow Zone`. The old ``${...} || "Station • Slow Zone"`` fallback was unreachable — template literals are always truthy.

Still bridged (tracked with inline TODOs):

- `app/routes/follow.$runId.ts` and `app/routes/stations.$stationId.tsx` each carry an `as Arrival[]` cast because `slow-zone` types `followTrain` / `getArrivalsForStation` as `Promise<unknown>`. The TODOs come out when the upstream narrowing ships.

Intentionally not touched:

- `ErrorBoundary` in `stations.tsx` and `stations._index.tsx` stays parameter-less. Neither reads the error, so adding an unused `Route.ErrorBoundaryProps` prop would be strictly worse than the status quo.

## Why?

The v7 upgrade landed the plumbing — `react-router typegen` in the `typecheck` script, `rootDirs` wired up in `tsconfig.json` — but consumers never moved to the generated types. `LoaderFunctionArgs`
& friends still work in v7 for back-compat, which made it easy to not finish.

Two wins from moving over:
- First, `params` and the inferred loader return flow into meta / component / error boundary without a hand-rolled `LoaderData` type repeating the contract.
- Second, every place the hand-rolled `LoaderData` types were quietly lying about upstream shapes is now either typed honestly (`ORDERED_STATIONS`) or carries an explicit, grep-able cast with a TODO (`arrivals` from `slow-zone`).